### PR TITLE
Fix docker paths and nginx video serving

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "1935:1935"
     volumes:
       - recordings:/tmp/recordings
-      - ./html/:/usr/share/nginx/html
+      - ./html:/var/www/vhosts/web
     depends_on:
       - php-fpm
 

--- a/nginx/.htpasswd
+++ b/nginx/.htpasswd
@@ -1,1 +1,1 @@
-htpasswd -cb .htpasswd admin test123
+admin:$apr1$JCEhOcp0$5FIiS4icyzMprCwMIxLmu/

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,8 +45,14 @@ http {
             rewrite ^(.*)$ /index.php?_url=$1 break;
         }
 
+
         location / {
             try_files $uri /index.php$is_args$args;
+        }
+
+        location /videos/ {
+            alias /tmp/recordings/;
+            autoindex on;
         }
 
         location ~ \.php$  {

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -9,7 +9,7 @@ RUN chmod +x /usr/local/bin/install-php-extensions && \
     docker-php-ext-install dom && \
     install-php-extensions xdebug ssh2 mysqli gd mongodb zip pcntl imagick bz2 xml pdo pdo_mysql
 
-RUN apk add dos2unix --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --allow-untruste
+RUN apk add dos2unix --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --allow-untrusted
 
 WORKDIR /var/www/vhosts/web
 


### PR DESCRIPTION
## Summary
- mount app code to the path expected by nginx
- expose recorded videos via `/videos/`
- correct typo in php-fpm Dockerfile
- add hashed credentials to `.htpasswd`

## Testing
- `docker-compose` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687668df44e883209cbb93f7493097a5